### PR TITLE
Update emotes to 0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Emotes
+
 RuneLite plugin that adds highlights and labels for emotes.
 
-Shift + right-click an emote in the emotes panel to add/remove highlighting, update colors to your current settings, 
+Shift + right-click an emote in the emotes panel to add/remove highlighting, update colors to your current settings,
 or change labels.
 
 ![demo](https://i.imgur.com/ZaEpZFy.gif)
@@ -9,4 +10,6 @@ or change labels.
 Text is overlaid at the bottom of each emote widget in the event that the clue items plugin overlays its text for emote
 clues, which should be at the top.
 
-Note that disabled emotes cannot be highlighted or scrolled to.
+The plugin also supports setting an emote to scroll to after the emotes UI is reset, e.g., when moving to/from
+instances. This can also be done by shift-right-clicking and choosing "scroll-on-reset". This can also be changed in 
+the plugin settings panel.

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'dev.yequi.emotes'
-version = '0.0.3'
+version = '0.0.4'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/dev/yequi/emotes/Emote.java
+++ b/src/main/java/dev/yequi/emotes/Emote.java
@@ -29,6 +29,7 @@ import static net.runelite.api.SpriteID.*;
 
 /**
  * Represents an emote in the emotes panel.
+ * Ordinals matter for saving EmoteHighlight items in config -> always add new emotes below existing
  */
 @Getter
 public enum Emote
@@ -60,57 +61,56 @@ public enum Emote
 
 	CLAP("Clap", EMOTE_CLAP),
 	SALUTE("Salute", EMOTE_SALUTE),
-	GOBLIN_BOW("Goblin Bow", EMOTE_GOBLIN_BOW),
-	GOBLIN_SALUTE("Goblin Salute", EMOTE_GOBLIN_SALUTE),
+	GOBLIN_BOW("Goblin Bow", EMOTE_GOBLIN_BOW, EMOTE_GOBLIN_BOW_LOCKED),
+	GOBLIN_SALUTE("Goblin Salute", EMOTE_GOBLIN_SALUTE, EMOTE_GOBLIN_SALUTE_LOCKED),
 
-	GLASS_BOX("Glass Box", EMOTE_GLASS_BOX),
-	CLIMB_ROPE("Climb Rope", EMOTE_CLIMB_ROPE),
-	LEAN("Lean", EMOTE_LEAN),
-	GLASS_WALL("Glass Wall", EMOTE_GLASS_WALL),
+	GLASS_BOX("Glass Box", EMOTE_GLASS_BOX, EMOTE_GLASS_BOX_LOCKED),
+	CLIMB_ROPE("Climb Rope", EMOTE_CLIMB_ROPE, EMOTE_CLIMB_ROPE_LOCKED),
+	LEAN("Lean", EMOTE_LEAN, EMOTE_LEAN_LOCKED),
+	GLASS_WALL("Glass Wall", EMOTE_GLASS_WALL, EMOTE_GLASS_BOX_LOCKED),
 
-	IDEA("Idea", EMOTE_IDEA),
-	STAMP("Stamp", EMOTE_STAMP),
-	FLAP("Flap", EMOTE_FLAP),
-	SLAP_HEAD("Slap Head", EMOTE_SLAP_HEAD),
+	IDEA("Idea", EMOTE_IDEA, EMOTE_IDEA_LOCKED),
+	STAMP("Stamp", EMOTE_STAMP, EMOTE_STAMP_LOCKED),
+	FLAP("Flap", EMOTE_FLAP, EMOTE_FLAP),
+	SLAP_HEAD("Slap Head", EMOTE_SLAP_HEAD, EMOTE_SLAP_HEAD_LOCKED),
 
-	ZOMBIE_WALK("Zombie Walk", EMOTE_ZOMBIE_WALK),
-	ZOMBIE_DANCE("Zombie Dance", EMOTE_ZOMBIE_DANCE),
-	SCARED("Scared", EMOTE_SCARED),
-	RABBIT_HOP("Rabbit Hop", EMOTE_RABBIT_HOP),
+	ZOMBIE_WALK("Zombie Walk", EMOTE_ZOMBIE_WALK, EMOTE_ZOMBIE_WALK_LOCKED),
+	ZOMBIE_DANCE("Zombie Dance", EMOTE_ZOMBIE_DANCE, EMOTE_ZOMBIE_DANCE_LOCKED),
+	SCARED("Scared", EMOTE_SCARED, EMOTE_SCARED_LOCKED),
+	RABBIT_HOP("Rabbit Hop", EMOTE_RABBIT_HOP, EMOTE_RABBIT_HOP_LOCKED),
 
-	SIT_UP("Sit up", EMOTE_SIT_UP),
-	PUSH_UP("Push up", EMOTE_PUSH_UP),
-	STAR_JUMP("Star jump", EMOTE_STAR_JUMP),
-	JOG("Jog", EMOTE_JOG),
+	SIT_UP("Sit up", EMOTE_SIT_UP, EMOTE_SIT_UP_LOCKED),
+	PUSH_UP("Push up", EMOTE_PUSH_UP, EMOTE_PUSH_UP_LOCKED),
+	STAR_JUMP("Star jump", EMOTE_STAR_JUMP, EMOTE_STAR_JUMP_LOCKED),
+	JOG("Jog", EMOTE_JOG, EMOTE_JOG_LOCKED),
 
-	FLEX("Flex", 2426),
-	ZOMBIE_HAND("Zombie Hand", EMOTE_ZOMBIE_HAND),
-	HYPERMOBILE_DRINKER("Hypermobile Drinker", EMOTE_HYPERMOBILE_DRINKER),
-	SKILL_CAPE("Skill Cape", EMOTE_SKILLCAPE),
+	FLEX("Flex", ExtraSpriteID.FLEX, ExtraSpriteID.FLEX_LOCKED),
+	ZOMBIE_HAND("Zombie Hand", EMOTE_ZOMBIE_HAND, EMOTE_ZOMBIE_HAND_LOCKED),
+	HYPERMOBILE_DRINKER("Hypermobile Drinker", EMOTE_HYPERMOBILE_DRINKER, EMOTE_HYPERMOBILE_DRINKER_LOCKED),
+	SKILL_CAPE("Skill Cape", EMOTE_SKILLCAPE, EMOTE_SKILLCAPE_LOCKED),
 
-	AIR_GUITAR("Air Guitar", EMOTE_AIR_GUITAR),
-	URI_TRANSFORM("Uri transform", EMOTE_URI_TRANSFORM),
-	SMOOTH_DANCE("Smooth dance", EMOTE_SMOOTH_DANCE),
-	CRAZY_DANCE("Crazy dance", EMOTE_CRAZY_DANCE),
+	AIR_GUITAR("Air Guitar", EMOTE_AIR_GUITAR, EMOTE_AIR_GUITAR_LOCKED),
+	URI_TRANSFORM("Uri transform", EMOTE_URI_TRANSFORM, EMOTE_URI_TRANSFORM_LOCKED),
+	SMOOTH_DANCE("Smooth dance", EMOTE_SMOOTH_DANCE, EMOTE_SMOOTH_DANCE_LOCKED),
+	CRAZY_DANCE("Crazy dance", EMOTE_CRAZY_DANCE, EMOTE_CRAZY_DANCE_LOCKED),
 
-	PREMIER_SHIELD("Premier Shield", EMOTE_PREMIER_SHIELD),
-	EXPLORE("Explore", 2423),
-	RELIC_UNLOCK_TL("Relic unlock (twisted)", 2424),
-	RELIC_UNLOCK_TBL("Relic unlock (trailblazer)", 2425),
-	FRAGMENT_UNLOCK("Fragment unlock", 3604),
-	PARTY("Party", 3606);
+	PREMIER_SHIELD("Premier Shield", EMOTE_PREMIER_SHIELD, EMOTE_PREMIER_SHIELD_LOCKED),
+	EXPLORE("Explore", ExtraSpriteID.EXPLORE, ExtraSpriteID.EXPLORE_LOCKED),
+	RELIC_UNLOCK("Relic unlock", ExtraSpriteID.RELIC_UNLOCK_TWISTED,
+		ExtraSpriteID.RELIC_UNLOCK_TRAILBLAZER, ExtraSpriteID.FRAGMENT_UNLOCK, ExtraSpriteID.RELIC_UNLOCK_LOCKED),
+	PARTY("Party", ExtraSpriteID.PARTY, ExtraSpriteID.PARTY_LOCKED);
 
 	private final String label;
-	private final int spriteId;
+	private final int[] spriteIds;
 
 	public String toString()
 	{
 		return label;
 	}
 
-	Emote(String label, int spriteId)
+	Emote(String label, int... spriteIds)
 	{
 		this.label = label;
-		this.spriteId = spriteId;
+		this.spriteIds = spriteIds;
 	}
 }

--- a/src/main/java/dev/yequi/emotes/EmoteHighlight.java
+++ b/src/main/java/dev/yequi/emotes/EmoteHighlight.java
@@ -8,6 +8,7 @@ import lombok.With;
 @Value
 public class EmoteHighlight
 {
+	// as of v0.0.4, this is the Emote enum ordinal, not the sprite id
 	int spriteId;
 	Color fillColor;
 	Color borderColor;

--- a/src/main/java/dev/yequi/emotes/EmoteOverlay.java
+++ b/src/main/java/dev/yequi/emotes/EmoteOverlay.java
@@ -76,21 +76,27 @@ public class EmoteOverlay extends Overlay
 			return null;
 		}
 		Map<Integer, EmoteHighlight> highlights = plugin.getHighlights();
-		if (highlights.isEmpty())
-		{
-			return null;
-		}
-		int spriteIdToScrollTo = config.emoteToScrollTo().getSpriteId();
+		int[] spriteIds = config.emoteToScrollTo().getSpriteIds();
 		for (Widget emoteWidget : emoteContainer.getDynamicChildren())
 		{
-			if (emoteWidget.getSpriteId() == spriteIdToScrollTo)
+			// scroll to the specified item
+			for (int spriteId : spriteIds)
 			{
-				plugin.scrollToHighlight(emoteWidget);
+				if (spriteId == emoteWidget.getSpriteId())
+				{
+					plugin.scrollToHighlight(emoteWidget);
+					break;
+				}
 			}
-			EmoteHighlight value = highlights.get(emoteWidget.getSpriteId());
-			if (value != null)
+			// highlight the emote
+			Emote emote = EmotesPlugin.emoteFromWidget(emoteWidget);
+			if (emote != null)
 			{
-				highlight(graphics, value, emoteWidget, emoteWindow);
+				EmoteHighlight value = highlights.get(emote.ordinal());
+				if (value != null)
+				{
+					highlight(graphics, value, emoteWidget, emoteWindow);
+				}
 			}
 		}
 		return null;

--- a/src/main/java/dev/yequi/emotes/EmotesConfig.java
+++ b/src/main/java/dev/yequi/emotes/EmotesConfig.java
@@ -102,6 +102,15 @@ public interface EmotesConfig extends Config
 	}
 
 	@ConfigItem(
+		position = 6,
+		keyName = "emoteToScrollTo",
+		name = "Emote to scroll to",
+		description = "Scrolls to this emote whenever the tab resets (if scroll mode enabled)",
+		hidden = true
+	)
+	void setEmoteToScrollTo(Emote emote);
+
+	@ConfigItem(
 		position = 7,
 		keyName = "scrollMode",
 		name = "Scroll mode",
@@ -121,6 +130,26 @@ public interface EmotesConfig extends Config
 	)
 	void setScrollMode(ScrollMode mode);
 
+	@ConfigItem(
+		keyName = "savedHighlightInfoV2",
+		name = "Highlighted emote info",
+		description = "Map of sprite ids to highlight",
+		hidden = true
+	)
+	default String savedHighlightInfoV2()
+	{
+		return "";
+	}
+
+	@ConfigItem(
+		keyName = "savedHighlightInfoV2",
+		name = "Highlighted emote info",
+		description = "Map of sprite ids to highlight",
+		hidden = true
+	)
+	void setSavedHighlightInfoV2(String serializedInfo);
+
+	// below configs are deprecated and will be eventually removed
 	@ConfigItem(
 		keyName = "savedHighlightInfo",
 		name = "Highlighted emote info",

--- a/src/main/java/dev/yequi/emotes/ExtraSpriteID.java
+++ b/src/main/java/dev/yequi/emotes/ExtraSpriteID.java
@@ -1,0 +1,18 @@
+package dev.yequi.emotes;
+
+public class ExtraSpriteID
+{
+	public static final int FLEX = 2426;
+	public static final int FLEX_LOCKED = 2429;
+
+	public static final int EXPLORE = 2423;
+	public static final int EXPLORE_LOCKED = 2427;
+
+	public static final int RELIC_UNLOCK_TWISTED = 2424;
+	public static final int RELIC_UNLOCK_TRAILBLAZER = 2425;
+	public static final int FRAGMENT_UNLOCK = 3604;
+	public static final int RELIC_UNLOCK_LOCKED = 2428;
+
+	public static final int PARTY = 3606;
+	public static final int PARTY_LOCKED = 2430;
+}


### PR DESCRIPTION
Fixes #3 
* Change highlight and menu opt behavior to rely less on individual sprite ids, instead inspect opt name/action
* Allow locked emotes to be highlighted/scrolled
* Fixed bug where scrolling was skipped if user didn't have any highlights